### PR TITLE
Allow backlight control through codam-web-greeter

### DIFF
--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -13,9 +13,18 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - light-locker
-    - xprintidle
+    - light-locker # For locking the screen
+    - xprintidle # For detecting idle time of a user
+    - ddcci-dkms # For backlight control on external monitors
   # Assume lightdm, nodejs and npm are already installed by 42.app
+
+- name: Enable ddcci-backlight kernel module
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  become: true
+  modprobe:
+    name: ddcci-backlight
+    state: present
+    persistent: present
 
 - name: Check if xbacklight binary exists
   tags: [codam.webgreeter, codam.webgreeter.init]

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -55,7 +55,7 @@
     name: lightdm
     groups: video
     append: yes
-  when: video_group.stdout == ""
+  when: video_group.stdout != ""
 
 - name: Download nody-greeter deb to ansible controller
   tags: [codam.webgreeter, codam.webgreeter.init]

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -17,6 +17,46 @@
     - xprintidle
   # Assume lightdm, nodejs and npm are already installed by 42.app
 
+- name: Check if xbacklight binary exists
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  shell:
+    cmd: "which xbacklight"
+  register: xbacklight_bin
+  changed_when: false
+  failed_when: false
+
+- name: Clone acpilight repository
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  git:
+    repo: https://gitlab.com/wavexx/acpilight.git
+    dest: /tmp/acpilight
+    version: v1.2
+  when: xbacklight_bin.stdout == "" # Only when xbacklight is not already available (acpilight is a replacement and has better support)
+
+- name: Install acpilight
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  become: true
+  make:
+    target: install
+    chdir: /tmp/acpilight
+  when: xbacklight_bin.stdout == ""
+
+- name: Check if video group exists # Only exists if acpilight was installed
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  shell:
+    cmd: "getent group video"
+  register: video_group
+  changed_when: false
+  failed_when: false
+
+- name: Add lightdm user to video group
+  tags: [codam.webgreeter, codam.webgreeter.init]
+  user:
+    name: lightdm
+    groups: video
+    append: yes
+  when: video_group.stdout == ""
+
 - name: Download nody-greeter deb to ansible controller
   tags: [codam.webgreeter, codam.webgreeter.init]
   delegate_to: localhost


### PR DESCRIPTION
This PR makes it possible to control the brightness of a monitor through the login and lock screen by installing [acpilight](https://gitlab.com/wavexx/acpilight), a replacement for the xbacklight package that just works better.

For external monitors, this requires the ddcci-dkms package for the ddcci-backlight kernel module.