### PR TITLE
Ensure lightdm.conf ends with newline

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -49,6 +49,12 @@
     group: root
     mode: '0644'
 
+- name: Ensure lightdm.conf ends with newline
+  tags: [codam.webgreeter, codam.webgreeter.setup]
+  become: true
+  ansible.builtin.shell: |
+    sed -i -e '$a\' /etc/lightdm/lightdm.conf
+
 - name: Configure lightdm
   tags: [codam.webgreeter, codam.webgreeter.setup]
   become: true


### PR DESCRIPTION
In some case, if you have local modification or local role who does not add a trailing newline you can have error with the `Configure lightdm` task