### PR TITLE
Update lightdm configuration paths to greeter.conf

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -49,17 +49,17 @@
     group: root
     mode: '0644'
 
-- name: Ensure lightdm.conf ends with newline
+- name: Ensure lightdm.conf.d/greeter.conf ends with newline
   tags: [codam.webgreeter, codam.webgreeter.setup]
   become: true
   shell:
-    cmd: "sed -i '$a\\' /etc/lightdm/lightdm.conf"
+    cmd: "sed -i '$a\\' /etc/lightdm/lightdm.conf.d/greeter.conf"
 
 - name: Configure lightdm
   tags: [codam.webgreeter, codam.webgreeter.setup]
   become: true
   lineinfile:
-    path: /etc/lightdm/lightdm.conf
+    path: /etc/lightdm/lightdm.conf.d/greeter.conf
     line: "{{ item }}"
     insertafter: "[SeatDefaults]"
     regexp: '^#?{{ item.split("=")[0] }}=' # regexp with optional comment start and up to the = sign to replace the value
@@ -83,7 +83,7 @@
   tags: [never, codam.webgreeter.revertdisplaysetup] # this task is only needed when you want to revert the display-setup hook changes made by version v1.2.0 - v1.2.1
   become: true
   lineinfile:
-    path: /etc/lightdm/lightdm.conf
+    path: /etc/lightdm/lightdm.conf.d/greeter.conf
     state: absent
     insertbefore: 'session-setup-script='
     regexp: '^display-setup-script='
@@ -102,7 +102,7 @@
   tags: [codam.webgreeter, codam.webgreeter.setup, hooks.d]
   become: true
   lineinfile:
-    path: /etc/lightdm/lightdm.conf
+    path: /etc/lightdm/lightdm.conf.d/greeter.conf
     line: greeter-setup-script=/usr/share/42/scripts/hook-greeter-setup.sh
     insertbefore: 'session-setup-script='
     state: present


### PR DESCRIPTION
Since the latest version of the 42.common all configs are now in the lightdm.conf.d/ folder so we need this fix to be able to deploy